### PR TITLE
chore(atc-router): from a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,21 @@ ARG ARCHITECTURE=x86_64
 ARG DOCKER_REGISTRY=ghcr.io
 ARG DOCKER_IMAGE_NAME
 
+# ATC-router image to copy in the installed atc-router
+# List out all image permutations to trick dependabot
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.1.3-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.1.3-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.1.3-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.1.3-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
+
+# Kong openssl image as our base
 # List out all image permutations to trick dependabot
 FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.0-x86_64-linux-musl as x86_64-linux-musl
 FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.0-x86_64-linux-gnu as x86_64-linux-gnu
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.0-aarch64-linux-musl as aarch64-linux-musl
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.0-aarch64-linux-gnu as aarch64-linux-gnu
 
+FROM atc-router-$ARCHITECTURE-$OSTYPE as atc-router
 
 # Run the build script
 FROM $ARCHITECTURE-$OSTYPE as build
@@ -21,6 +30,7 @@ WORKDIR /tmp
 # Run our own tests
 # Re-run our predecessor tests
 ENV DEBUG=0
+COPY --from=atc-router / /
 RUN /test/*/test.sh && \
     /tmp/build.sh && \
     /tmp/test.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.1.3-aarch6
 
 # Kong openssl image as our base
 # List out all image permutations to trick dependabot
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.0-x86_64-linux-musl as x86_64-linux-musl
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.0-x86_64-linux-gnu as x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.0-aarch64-linux-musl as aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.0-aarch64-linux-gnu as aarch64-linux-gnu
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.3-x86_64-linux-musl as x86_64-linux-musl
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.0.3-x86_64-linux-gnu as x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.3-aarch64-linux-musl as aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.0.3-aarch64-linux-gnu as aarch64-linux-gnu
 
 FROM atc-router-$ARCHITECTURE-$OSTYPE as atc-router
 

--- a/build.sh
+++ b/build.sh
@@ -93,16 +93,6 @@ function main() {
         echo '--- installed luarocks ---'
     popd
 
-    arch=$(uname -m)
-
-    package_architecture=x86_64
-    if [ "$(arch)" == "aarch64" ]; then
-        package_architecture=aarch64
-    fi
-
-    curl -fsSLo atc-router.tar.gz https://github.com/hutchic-org/atc-router/releases/download/$ATC_ROUTER_VERSION/$package_architecture-unknown-$OSTYPE.tar.gz
-    tar -C /tmp/build -xvf atc-router.tar.gz
-
     mkdir -p /tmp/build/usr/local/lib/luarocks
     mkdir -p /tmp/build/usr/local/share/lua
     mkdir -p /tmp/build/usr/local/lib/lua

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,7 @@ function test() {
     grep _VERSION /usr/local/openresty/lualib/resty/websocket/*.lua
     luarocks --version
 
+    ls -la /usr/local/openresty/lualib/libatc_router.so
     #ldd /usr/local/openresty/lualib/libatc_router.so
 
     mv /tmp/buffer /tmp/build


### PR DESCRIPTION
By wrapping a pre-compiled atc-router in a docker image we get
- faster builds
- more consistent builds
- more reliable builds
- dependabot handles updates