### PR TITLE
fix(atc-router): fix how atc router gets included

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,9 @@ WORKDIR /tmp
 # Run our own tests
 # Re-run our predecessor tests
 ENV DEBUG=0
-COPY --from=atc-router / /
-RUN /test/*/test.sh && \
+COPY --from=atc-router / /atc-router
+RUN cp -R /atc-router/* /tmp/build/ && \
+    /test/*/test.sh && \
     /tmp/build.sh && \
     /tmp/test.sh && \
     /test/*/test.sh

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,7 @@ function test() {
     cp -R /tmp/build/* /
     mv /tmp/build /tmp/buffer # Check we didn't link dependencies to `/tmp/build/...`
 
+    ls -la /tmp/buffer/usr/local/openresty/bin/openresty
     /usr/local/openresty/bin/openresty -v 2>&1 | grep -q ${OPENRESTY_VERSION}
     /usr/local/openresty/bin/openresty -V 2>&1 | grep -q pcre
     /usr/local/openresty/bin/openresty -V 2>&1 | grep -q with-pcre=
@@ -22,12 +23,15 @@ function test() {
     /usr/local/openresty/bin/openresty -V 2>&1 | grep -q lua-resty-lmdb
     /usr/local/openresty/bin/openresty -V 2>&1 | grep -q lua-resty-events
     /usr/local/openresty/bin/resty -e 'print(jit.version)' | grep -q 'LuaJIT[[:space:]][[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+-[[:digit:]]\{8\}'
+    ls -la /tmp/buffer/usr/local/openresty/nginx/sbin/nginx
+    ls -la /tmp/buffer/usr/local/openresty/bin/resty
 
     ls -l /usr/local/openresty/lualib/resty/websocket/*.lua
     grep _VERSION /usr/local/openresty/lualib/resty/websocket/*.lua
     luarocks --version
 
-    ls -la /usr/local/openresty/lualib/libatc_router.so
+    ls -la /tmp/buffer/usr/local/openresty/lualib/libatc_router.so
+    ls -la /tmp/buffer/usr/local/openresty/lualib/resty/router/router.lua
     #ldd /usr/local/openresty/lualib/libatc_router.so
 
     mv /tmp/buffer /tmp/build


### PR DESCRIPTION
The atc-router components need to land in `/tmp/build/*`.

We can't `COPY --from=atc-router / /` as that will overwrite more than we desire so instead copy the compiled atc-router component to `/atc-router` then move it from there. Updated the tests so they will be correct going forward