### PR TITLE
fix(dependabot): Dockerfile hack to trick dependabot into doing it's job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,31 @@ ARG DOCKER_IMAGE_NAME
 # ATC-router image to copy in the installed atc-router
 # List out all image permutations to trick dependabot
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
+RUN echo 'noop'
+
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
+RUN echo 'noop'
+
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
+RUN echo 'noop'
+
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
+RUN echo 'noop'
+
 
 # Kong openssl image as our base
 # List out all image permutations to trick dependabot
 FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.4-x86_64-linux-musl as x86_64-linux-musl
+RUN echo 'noop'
+
 FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.4-x86_64-linux-gnu as x86_64-linux-gnu
+RUN echo 'noop'
+
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.4-aarch64-linux-musl as aarch64-linux-musl
+RUN echo 'noop'
+
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.4-aarch64-linux-gnu as aarch64-linux-gnu
+RUN echo 'noop'
 
 FROM atc-router-$ARCHITECTURE-$OSTYPE as atc-router
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,16 @@ ARG DOCKER_IMAGE_NAME
 # ATC-router image to copy in the installed atc-router
 # List out all image permutations to trick dependabot
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
-RUN echo 'noop'
+COPY touch /touch
 
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
-RUN echo 'noop'
+COPY touch /touch
 
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
-RUN echo 'noop'
+COPY touch /touch
 
 FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
-RUN echo 'noop'
+COPY touch /touch
 
 
 # Kong openssl image as our base

--- a/touch
+++ b/touch
@@ -1,0 +1,1 @@
+intentionally left empty


### PR DESCRIPTION
seems dependabot parser requires the `FROM Dockerimage` have at least one instruction