### PR TITLE
chore(deps): manually update the dependencies

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -6,17 +6,17 @@ name: Auto update PR's
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - 'main'
+    - main
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.6.0
-        with:
-          token: ${{ secrets.AUTO_MERGE_TOKEN }}
-          base: 'main'
-          required_approval_count: 0
-          require_passed_checks: true
-          sort: 'created'
-          direction: 'desc'
+    - name: Automatically update PR
+      uses: adRise/update-pr-branch@v0.6.0
+      with:
+        token: ${{ secrets.AUTO_MERGE_TOKEN }}
+        base: main
+        required_approval_count: 0
+        require_passed_checks: true
+        sort: created
+        direction: desc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: hutchic
+        password: ${{ secrets.GH_TOKEN }}
 
     - uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
         registry: ghcr.io
-        username: hutchic
-        password: ${{ secrets.GH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: docker/setup-qemu-action@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,18 @@ ARG DOCKER_IMAGE_NAME
 
 # ATC-router image to copy in the installed atc-router
 # List out all image permutations to trick dependabot
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
 
 
 # Kong openssl image as our base
 # List out all image permutations to trick dependabot
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.7-x86_64-linux-musl as x86_64-linux-musl
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.7-x86_64-linux-gnu as x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.7-aarch64-linux-musl as aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.7-aarch64-linux-gnu as aarch64-linux-gnu
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.8-x86_64-linux-musl as x86_64-linux-musl
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.8-x86_64-linux-gnu as x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.8-aarch64-linux-musl as aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.8-aarch64-linux-gnu as aarch64-linux-gnu
 
 FROM atc-router-$ARCHITECTURE-$OSTYPE as atc-router
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ ARG DOCKER_IMAGE_NAME
 
 # ATC-router image to copy in the installed atc-router
 # List out all image permutations to trick dependabot
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
+FROM ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
+FROM ghcr.io/hutchic-org/atc-router-compiled:1.3.15-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
+FROM ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
+FROM ghcr.io/hutchic-org/atc-router-compiled:1.3.15-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
 
 
 # Kong openssl image as our base

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,18 @@ ARG DOCKER_IMAGE_NAME
 
 # ATC-router image to copy in the installed atc-router
 # List out all image permutations to trick dependabot
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.8-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-x86_64-unknown-linux-musl as atc-router-x86_64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-x86_64-unknown-linux-gnu as atc-router-x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-aarch64-unknown-linux-musl as atc-router-aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/atc-router-compiled:1.3.10-aarch64-unknown-linux-gnu as atc-router-aarch64-linux-gnu
 
 
 # Kong openssl image as our base
 # List out all image permutations to trick dependabot
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.4-x86_64-linux-musl as x86_64-linux-musl
-RUN echo 'noop'
-
-FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.4-x86_64-linux-gnu as x86_64-linux-gnu
-RUN echo 'noop'
-
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.4-aarch64-linux-musl as aarch64-linux-musl
-RUN echo 'noop'
-
-FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.4-aarch64-linux-gnu as aarch64-linux-gnu
-RUN echo 'noop'
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.7-x86_64-linux-musl as x86_64-linux-musl
+FROM --platform=linux/amd64 ghcr.io/hutchic-org/kong-openssl:1.2.7-x86_64-linux-gnu as x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.7-aarch64-linux-musl as aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/hutchic-org/kong-openssl:1.2.7-aarch64-linux-gnu as aarch64-linux-gnu
 
 FROM atc-router-$ARCHITECTURE-$OSTYPE as atc-router
 


### PR DESCRIPTION
dependabot has a bug / open PR related to why it can't update this cleanly. Until that's resolved handling the update manually